### PR TITLE
fix: complete vaultwarden kurl setup and fix make release

### DIFF
--- a/applications/vaultwarden/Makefile
+++ b/applications/vaultwarden/Makefile
@@ -1,0 +1,135 @@
+manifests_dir := $(shell pwd)/manifests
+chart_archives := $(wildcard $(manifests_dir)/*.tgz)
+
+ARGS = $(filter-out $@,$(MAKECMDGOALS))
+%:
+	@:
+
+SHELL := /bin/bash
+.SHELLFLAGS = -x +u
+
+# Define the base path to your Helm charts directory
+HELM_CHARTS_DIR = ./charts
+
+# Define the path to your target KOTS directory
+KOTS_DIR = ./manifests
+
+# Replicated app slug (override with REPLICATED_APP env var)
+APP_SLUG ?= $(REPLICATED_APP)
+
+# Release channel (default: Unstable)
+CHANNEL ?= Unstable
+
+# Define the function to extract chartVersion from KOTS HelmChart CR
+define get_kots_chart_version
+	grep 'chartVersion:' $(1) | sed 's/.*chartVersion: //'
+endef
+
+# Function to get chart version from Chart.yaml
+define get_helm_chart_version
+	helm show chart $(1) | grep '^version:' | cut -d ' ' -f 2
+endef
+
+# Target to update chart dependencies
+.PHONY: update-chart-dependencies
+update-chart-dependencies:
+	@for chart in $(HELM_CHARTS_DIR)/*; do \
+		if [ -f "$$chart/Chart.yaml" ]; then \
+			echo "Updating dependencies for $$chart"; \
+			helm dependency update --skip-refresh $$chart; \
+		fi \
+	done
+
+# Target to package charts and update versions in KOTS manifests
+.PHONY: package-and-update
+package-and-update: update-chart-dependencies
+	@for chart in $(HELM_CHARTS_DIR)/*; do \
+		if [ -f "$$chart/Chart.yaml" ]; then \
+			echo "Packaging $$chart"; \
+			helm package $$chart -d $(KOTS_DIR); \
+			version=$$(eval $(call get_helm_chart_version,$$chart)); \
+			chart_name=$$(basename $$chart); \
+			echo "Updating chartVersion to $$version in $(KOTS_DIR)/$$chart_name-chart.yaml"; \
+			sed -i.bak "s|chartVersion: [0-9a-zA-Z._-]*|chartVersion: $$version|g" $(KOTS_DIR)/$$chart_name-chart.yaml && rm -f $(KOTS_DIR)/$$chart_name-chart.yaml.bak; \
+		fi \
+	done
+
+# Lint all charts
+.PHONY: lint
+lint:
+	@for chart in $(HELM_CHARTS_DIR)/*; do \
+		if [ -f "$$chart/Chart.yaml" ]; then \
+			echo "Linting $$chart"; \
+			helm lint $$chart; \
+		fi \
+	done
+
+# Template all charts (dry-run validation)
+.PHONY: template
+template:
+	@for chart in $(HELM_CHARTS_DIR)/*; do \
+		if [ -f "$$chart/Chart.yaml" ]; then \
+			echo "Templating $$chart"; \
+			helm template test-release $$chart --dry-run; \
+		fi \
+	done
+
+# Clean chart archives from manifests dir and dependency archives
+.PHONY: clean
+clean:
+	rm -f $(KOTS_DIR)/*.tgz $(HELM_CHARTS_DIR)/*/charts/*.tgz
+
+# Create a Replicated release and promote to channel
+.PHONY: release
+release: clean package-and-update
+	replicated release create --yaml-dir $(KOTS_DIR) --promote $(CHANNEL) --auto -y
+
+# Validate the full config contract (KOTS Config items vs HelmChart CR references)
+.PHONY: validate
+validate: lint
+	@echo "Validating KOTS config contract..."
+	@ERRORS=0; \
+	CONFIG_ITEMS=$$(yq -r '.spec.groups[].items[].name' $(KOTS_DIR)/kots-config.yaml 2>/dev/null | sort -u); \
+	HELMCHART_REFS=$$( \
+		grep -oE 'ConfigOption "([^"]+)"' $(KOTS_DIR)/vaultwarden-chart.yaml 2>/dev/null | sed 's/ConfigOption "//;s/"//'; \
+		grep -oE 'ConfigOptionEquals "([^"]+)"' $(KOTS_DIR)/vaultwarden-chart.yaml 2>/dev/null | sed 's/ConfigOptionEquals "//;s/"//' \
+	); \
+	HELMCHART_REFS=$$(echo "$$HELMCHART_REFS" | sort -u); \
+	echo "=== KOTS Config items ==="; \
+	echo "$$CONFIG_ITEMS"; \
+	echo ""; \
+	echo "=== ConfigOption references in HelmChart CR ==="; \
+	echo "$$HELMCHART_REFS"; \
+	echo ""; \
+	for ref in $$HELMCHART_REFS; do \
+		if ! echo "$$CONFIG_ITEMS" | grep -qx "$$ref"; then \
+			echo "ERROR: HelmChart references ConfigOption '$$ref' but no matching Config item found"; \
+			ERRORS=$$((ERRORS + 1)); \
+		fi \
+	done; \
+	for item in $$CONFIG_ITEMS; do \
+		if ! echo "$$HELMCHART_REFS" | grep -qx "$$item"; then \
+			echo "WARNING: Config item '$$item' is not referenced by any HelmChart CR"; \
+		fi \
+	done; \
+	if [ $$ERRORS -gt 0 ]; then \
+		echo "FAILED: $$ERRORS error(s) found"; \
+		exit 1; \
+	else \
+		echo "Config contract validation passed!"; \
+	fi
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  make release                - Clean, package charts, create & promote Replicated release"
+	@echo "  make package-and-update     - Package Helm charts and sync versions to KOTS manifests"
+	@echo "  make update-chart-dependencies - Update Helm chart dependencies"
+	@echo "  make lint                   - Lint all Helm charts"
+	@echo "  make template               - Template all Helm charts (dry-run)"
+	@echo "  make validate               - Validate KOTS config contract"
+	@echo "  make clean                  - Remove chart archives"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  REPLICATED_APP  - Replicated app slug (required for release)"
+	@echo "  CHANNEL         - Release channel (default: Unstable)"

--- a/applications/vaultwarden/README.md
+++ b/applications/vaultwarden/README.md
@@ -1,0 +1,72 @@
+# Vaultwarden - kURL Platform Example
+
+A Replicated platform example for distributing [Vaultwarden](https://github.com/dani-garcia/vaultwarden), a lightweight Bitwarden-compatible password manager server.
+
+This example demonstrates:
+
+- Helm chart packaging for Replicated distribution
+- KOTS Admin Console integration with Config screen
+- kURL installer specification for bare-metal/VM installs
+- Air-gap image rewriting via `optionalValues`
+- Preflight checks and support bundle collection
+
+## Quick Start
+
+### Prerequisites
+
+- [Replicated CLI](https://docs.replicated.com/reference/replicated-cli-installing)
+- Helm 3.x
+- `REPLICATED_APP` environment variable set to your app slug
+
+### Create a Release
+
+```bash
+make release
+```
+
+This will:
+1. Clean old chart archives
+2. Update Helm chart dependencies (pulls the Replicated SDK subchart)
+3. Package the vaultwarden Helm chart
+4. Sync the chart version into the KOTS HelmChart CR
+5. Create a Replicated release from `manifests/` and promote to Unstable
+
+### Other Commands
+
+```bash
+make lint       # Lint Helm charts
+make template   # Dry-run template rendering
+make validate   # Check KOTS Config <-> HelmChart CR contract
+make clean      # Remove .tgz archives
+make help       # Show all targets
+```
+
+## Architecture
+
+```
+vaultwarden/
+  charts/
+    vaultwarden/          # Helm chart
+      Chart.yaml          # Chart metadata + Replicated SDK dependency
+      values.yaml         # Default values
+      templates/          # Kubernetes manifests
+  manifests/              # KOTS release directory (yaml-dir pattern)
+    kots-app.yaml         # KOTS Application spec
+    kots-config.yaml      # KOTS Config screen
+    vaultwarden-chart.yaml # HelmChart CR (maps Config -> Helm values)
+    kots-preflight.yaml   # Preflight checks
+    kots-support-bundle.yaml # Support bundle spec
+    kurl-installer.yaml   # kURL installer specification
+    k8s-app.yaml          # Kubernetes Application CRD
+```
+
+## Configuration
+
+The KOTS Config screen provides:
+
+| Group | Items |
+|-------|-------|
+| Application Settings | Domain, signups toggle, admin token, log level |
+| Database | SQLite (embedded) or external PostgreSQL |
+| Storage | Volume size and storage class |
+| Ingress | Enable/disable, class, hostname, TLS |

--- a/applications/vaultwarden/charts/vaultwarden/Chart.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/Chart.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v2
+name: vaultwarden
+description: A Helm chart for Vaultwarden - a lightweight Bitwarden-compatible password manager server
+type: application
+version: 0.1.0
+appVersion: 1.32.7
+kubeVersion: '>=1.26.0-0'
+maintainers:
+  - name: kriscoleman
+    url: https://github.com/kriscoleman
+dependencies:
+  - name: replicated
+    version: '^1.0.0'
+    repository: 'oci://registry.replicated.com/library'
+    condition: replicated.enabled

--- a/applications/vaultwarden/charts/vaultwarden/templates/NOTES.txt
+++ b/applications/vaultwarden/charts/vaultwarden/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "vaultwarden.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "vaultwarden.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "vaultwarden.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "vaultwarden.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/_helpers.tpl
+++ b/applications/vaultwarden/charts/vaultwarden/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vaultwarden.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "vaultwarden.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vaultwarden.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vaultwarden.labels" -}}
+helm.sh/chart: {{ include "vaultwarden.chart" . }}
+{{ include "vaultwarden.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vaultwarden.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vaultwarden.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vaultwarden.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vaultwarden.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database URL - returns the appropriate database connection string
+*/}}
+{{- define "vaultwarden.databaseUrl" -}}
+{{- if eq .Values.database.type "external_postgres" }}
+{{- .Values.database.url }}
+{{- else }}
+{{- print "/data/db.sqlite3" }}
+{{- end }}
+{{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/deployment.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vaultwarden.fullname" . }}
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vaultwarden.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "vaultwarden.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vaultwarden.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            {{- if .Values.env.DOMAIN }}
+            - name: DOMAIN
+              value: {{ .Values.env.DOMAIN | quote }}
+            {{- end }}
+            - name: SIGNUPS_ALLOWED
+              value: {{ .Values.env.SIGNUPS_ALLOWED | quote }}
+            {{- if .Values.env.ADMIN_TOKEN }}
+            - name: ADMIN_TOKEN
+              value: {{ .Values.env.ADMIN_TOKEN | quote }}
+            {{- end }}
+            - name: LOG_LEVEL
+              value: {{ .Values.env.LOG_LEVEL | quote }}
+            {{- if eq .Values.database.type "external_postgres" }}
+            - name: DATABASE_URL
+              value: {{ .Values.database.url | quote }}
+            {{- else }}
+            - name: DATABASE_URL
+              value: "/data/db.sqlite3"
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "vaultwarden.fullname" . }}-data
+      {{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/ingress.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "vaultwarden.fullname" . }}
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "vaultwarden.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/pvc.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vaultwarden.fullname" . }}-data
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/service.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vaultwarden.fullname" . }}
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "vaultwarden.selectorLabels" . | nindent 4 }}

--- a/applications/vaultwarden/charts/vaultwarden/templates/serviceaccount.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vaultwarden.serviceAccountName" . }}
+  labels:
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/applications/vaultwarden/charts/vaultwarden/values.yaml
+++ b/applications/vaultwarden/charts/vaultwarden/values.yaml
@@ -1,0 +1,94 @@
+# -- Number of Vaultwarden replicas
+replicaCount: 1
+
+image:
+  # -- Vaultwarden image repository
+  repository: vaultwarden/server
+  # -- Vaultwarden image tag
+  tag: 1.32.7
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets
+imagePullSecrets: []
+
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Whether to create a service account
+  create: true
+  # -- Annotations for the service account
+  annotations: {}
+  # -- Name of the service account
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod security context
+podSecurityContext: {}
+
+# -- Container security context
+securityContext: {}
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 80
+
+ingress:
+  # -- Whether to create an Ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: vaultwarden.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+
+# -- Container resources
+resources: {}
+
+persistence:
+  # -- Whether to enable persistence
+  enabled: true
+  # -- Storage class for the PVC
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- PVC size
+  size: 10Gi
+
+# -- Vaultwarden environment variables
+env:
+  # -- Domain for Vaultwarden (used for email links, etc.)
+  DOMAIN: "https://vaultwarden.local"
+  # -- Enable signups
+  SIGNUPS_ALLOWED: "true"
+  # -- Enable admin panel
+  ADMIN_TOKEN: ""
+  # -- Log level
+  LOG_LEVEL: "info"
+
+# -- Database configuration
+database:
+  # -- Database type: sqlite or external_postgres
+  type: sqlite
+  # -- External postgres connection URL (when type is external_postgres)
+  # Format: postgresql://user:password@host:port/database
+  url: ""
+
+# -- Replicated SDK configuration
+replicated:
+  enabled: true

--- a/applications/vaultwarden/manifests/k8s-app.yaml
+++ b/applications/vaultwarden/manifests/k8s-app.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: vaultwarden
+spec:
+  descriptor:
+    links:
+      - description: Open Vaultwarden
+        url: 'repl{{ ConfigOption "vaultwarden_domain" }}'

--- a/applications/vaultwarden/manifests/kots-app.yaml
+++ b/applications/vaultwarden/manifests/kots-app.yaml
@@ -1,0 +1,16 @@
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: vaultwarden
+spec:
+  title: Vaultwarden
+  icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
+  statusInformers:
+    - deployment/vaultwarden
+  allowRollback: true
+  proxyPublicImages: true
+  ports:
+    - serviceName: vaultwarden
+      servicePort: 80
+      localPort: 8080
+      applicationUrl: "http://vaultwarden"

--- a/applications/vaultwarden/manifests/kots-config.yaml
+++ b/applications/vaultwarden/manifests/kots-config.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: vaultwarden
+spec:
+  groups:
+    # Application settings
+    - name: app_settings
+      title: Application Settings
+      description: Configure Vaultwarden application settings
+      items:
+        - name: vaultwarden_domain
+          title: Vaultwarden Domain
+          help_text: |
+            The domain where Vaultwarden will be accessible (e.g., https://vault.example.com).
+            This is used for generating email links and configuring the web vault.
+          type: text
+          default: "https://vaultwarden.example.com"
+          required: true
+        - name: vaultwarden_signups_allowed
+          title: Allow Signups
+          help_text: Whether to allow new user registrations.
+          type: bool
+          default: "1"
+        - name: vaultwarden_admin_token
+          title: Admin Panel Token
+          help_text: |
+            Token for accessing the /admin panel. Leave empty to disable the admin panel.
+            A random token is auto-generated; change it if needed.
+          type: password
+          hidden: true
+          value: '{{repl RandomString 48}}'
+        - name: vaultwarden_log_level
+          title: Log Level
+          type: select_one
+          default: info
+          items:
+            - name: trace
+              title: Trace
+            - name: debug
+              title: Debug
+            - name: info
+              title: Info
+            - name: warn
+              title: Warn
+            - name: error
+              title: Error
+
+    # Database settings
+    - name: database_settings
+      title: Database
+      description: Configure the database backend for Vaultwarden
+      items:
+        - name: database_type
+          title: Database Type
+          help_text: |
+            SQLite is simple and suitable for small deployments. External PostgreSQL
+            is recommended for production use with multiple users.
+          type: select_one
+          default: sqlite
+          items:
+            - name: sqlite
+              title: SQLite (Embedded)
+            - name: external_postgres
+              title: External PostgreSQL
+        - name: external_postgres_url
+          title: PostgreSQL Connection URL
+          help_text: |
+            Full connection URL, e.g.: postgresql://user:password@host:5432/vaultwarden
+          type: text
+          when: '{{repl ConfigOptionEquals "database_type" "external_postgres"}}'
+          required: true
+
+    # Storage settings
+    - name: storage_settings
+      title: Storage
+      description: Configure persistent storage for Vaultwarden data
+      items:
+        - name: storage_size
+          title: Data Volume Size
+          help_text: Size of the persistent volume for Vaultwarden data (attachments, icons, etc.)
+          type: text
+          default: "10Gi"
+        - name: storage_class
+          title: Storage Class
+          help_text: Leave empty to use the cluster default storage class.
+          type: text
+          default: ""
+
+    # Ingress settings
+    - name: ingress_settings
+      title: Ingress
+      description: Configure ingress for accessing Vaultwarden
+      when: 'repl{{ ne Distribution "embedded-cluster" }}'
+      items:
+        - name: ingress_enabled
+          title: Enable Ingress
+          type: bool
+          default: "0"
+        - name: ingress_class
+          title: Ingress Class Name
+          type: text
+          default: "nginx"
+          when: '{{repl ConfigOptionEquals "ingress_enabled" "1"}}'
+        - name: ingress_host
+          title: Ingress Hostname
+          type: text
+          default: "vaultwarden.example.com"
+          when: '{{repl ConfigOptionEquals "ingress_enabled" "1"}}'
+          required: true
+        - name: ingress_tls_type
+          title: TLS Type
+          type: select_one
+          default: none
+          when: '{{repl ConfigOptionEquals "ingress_enabled" "1"}}'
+          items:
+            - name: none
+              title: None
+            - name: self_signed
+              title: Self Signed
+            - name: user_provided
+              title: User Provided
+        - name: ingress_tls_cert
+          title: TLS Certificate
+          type: file
+          when: '{{repl and (ConfigOptionEquals "ingress_enabled" "1") (ConfigOptionEquals "ingress_tls_type" "user_provided")}}'
+          required: true
+        - name: ingress_tls_key
+          title: TLS Private Key
+          type: file
+          when: '{{repl and (ConfigOptionEquals "ingress_enabled" "1") (ConfigOptionEquals "ingress_tls_type" "user_provided")}}'
+          required: true

--- a/applications/vaultwarden/manifests/kots-preflight.yaml
+++ b/applications/vaultwarden/manifests/kots-preflight.yaml
@@ -1,0 +1,53 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: vaultwarden
+spec:
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.26.0"
+              message: Vaultwarden requires Kubernetes 1.26.0 or later.
+              uri: https://kubernetes.io
+          - pass:
+              message: Kubernetes version is compatible.
+    - nodeResources:
+        checkName: CPU capacity
+        outcomes:
+          - fail:
+              when: "sum(cpuAllocatable) < 1"
+              message: The cluster must have at least 1 CPU core allocatable.
+          - warn:
+              when: "sum(cpuAllocatable) < 2"
+              message: The cluster has less than 2 CPU cores allocatable. This may affect performance.
+          - pass:
+              message: The cluster has sufficient CPU resources.
+    - nodeResources:
+        checkName: Memory capacity
+        outcomes:
+          - fail:
+              when: "sum(memoryAllocatable) < 1073741824"
+              message: The cluster must have at least 1 GiB of allocatable memory.
+          - warn:
+              when: "sum(memoryAllocatable) < 2147483648"
+              message: The cluster has less than 2 GiB of allocatable memory. This may affect performance.
+          - pass:
+              message: The cluster has sufficient memory.
+    - storageClass:
+        checkName: Default storage class
+        outcomes:
+          - fail:
+              message: No default storage class found. Vaultwarden requires persistent storage.
+          - pass:
+              message: A default storage class is available.
+    - containerRuntime:
+        outcomes:
+          - fail:
+              when: "== gvisor"
+              message: Vaultwarden does not support the gVisor container runtime.
+          - pass:
+              message: A supported container runtime is present on all nodes.
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}

--- a/applications/vaultwarden/manifests/kots-support-bundle.yaml
+++ b/applications/vaultwarden/manifests/kots-support-bundle.yaml
@@ -1,0 +1,41 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: vaultwarden
+spec:
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+    - logs:
+        selector:
+          - app.kubernetes.io/name=vaultwarden
+        limits:
+          maxLines: 10000
+  analyzers:
+    - deploymentStatus:
+        name: vaultwarden
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: The Vaultwarden deployment does not have any ready replicas.
+          - pass:
+              message: The Vaultwarden deployment is running.
+    - clusterPodStatuses:
+        outcomes:
+          - fail:
+              when: "!= Healthy"
+              message: "Pod {{ .Name }} is unhealthy: {{ .Status.Reason }}"
+    - containerRuntime:
+        outcomes:
+          - fail:
+              when: "== gvisor"
+              message: The gVisor container runtime is not supported.
+          - pass:
+              message: A supported container runtime is present on all nodes.
+    - storageClass:
+        checkName: Check for default storage class
+        outcomes:
+          - fail:
+              message: No default storage class found.
+          - pass:
+              message: Default storage class found.

--- a/applications/vaultwarden/manifests/kurl-installer.yaml
+++ b/applications/vaultwarden/manifests/kurl-installer.yaml
@@ -1,0 +1,23 @@
+apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: vaultwarden
+spec:
+  kubernetes:
+    version: 1.28.x
+  containerd:
+    version: 1.6.x
+  flannel:
+    version: 0.25.x
+  openebs:
+    version: 3.9.x
+    isLocalPVEnabled: true
+    localPVStorageClassName: local
+  minio:
+    version: 2024-01-16T16-07-38Z
+  kotsadm:
+    version: latest
+  registry:
+    version: 2.8.x
+  ekco:
+    version: latest

--- a/applications/vaultwarden/manifests/vaultwarden-chart.yaml
+++ b/applications/vaultwarden/manifests/vaultwarden-chart.yaml
@@ -1,0 +1,63 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: vaultwarden
+spec:
+  chart:
+    name: vaultwarden
+    chartVersion: 0.1.0
+  weight: 10
+  helmUpgradeFlags:
+    - --wait
+    - --timeout
+    - 300s
+  builder: {}
+  values:
+    env:
+      DOMAIN: 'repl{{ ConfigOption "vaultwarden_domain" }}'
+      SIGNUPS_ALLOWED: 'repl{{ ConfigOption "vaultwarden_signups_allowed" }}'
+      ADMIN_TOKEN: 'repl{{ ConfigOption "vaultwarden_admin_token" }}'
+      LOG_LEVEL: 'repl{{ ConfigOption "vaultwarden_log_level" }}'
+    persistence:
+      size: 'repl{{ ConfigOption "storage_size" }}'
+      storageClass: 'repl{{ ConfigOption "storage_class" }}'
+    ingress:
+      className: 'repl{{ ConfigOption "ingress_class" }}'
+      hosts:
+        - host: 'repl{{ ConfigOption "ingress_host" }}'
+          paths:
+            - path: /
+              pathType: Prefix
+  optionalValues:
+    # Database type: external postgres
+    - when: 'repl{{ ConfigOptionEquals "database_type" "external_postgres" }}'
+      recursiveMerge: true
+      values:
+        database:
+          type: external_postgres
+          url: 'repl{{ ConfigOption "external_postgres_url" }}'
+    # Database type: sqlite (default)
+    - when: 'repl{{ ConfigOptionEquals "database_type" "sqlite" }}'
+      recursiveMerge: true
+      values:
+        database:
+          type: sqlite
+    # Ingress enabled
+    - when: 'repl{{ ConfigOptionEquals "ingress_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        ingress:
+          enabled: true
+    # Ingress disabled
+    - when: 'repl{{ ConfigOptionEquals "ingress_enabled" "0" }}'
+      recursiveMerge: true
+      values:
+        ingress:
+          enabled: false
+    # Air-gap image rewriting
+    - when: 'repl{{ HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        image:
+          repository: 'repl{{ LocalRegistryHost }}/repl{{ LocalRegistryNamespace }}/server'
+          pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Adds a complete **Vaultwarden** (Bitwarden-compatible password manager) platform example targeting **kURL** installs
- Helm chart with Replicated SDK subchart dependency, working deployment, service, PVC, ingress, and service account templates
- Full KOTS manifest set in `manifests/` directory (yaml-dir pattern):
  - `kots-app.yaml` -- Application spec with statusInformers and proxyPublicImages
  - `kots-config.yaml` -- Config screen: domain, signups, admin token, log level, database type toggle (SQLite/external PostgreSQL), storage settings, ingress with TLS options
  - `vaultwarden-chart.yaml` -- HelmChart CR mapping all Config items to Helm values, with `optionalValues` for database type, ingress toggle, and air-gap image rewriting (`HasLocalRegistry`/`LocalRegistryHost`/`LocalRegistryNamespace`)
  - `kots-preflight.yaml` -- Cluster version, CPU/memory allocatable, storage class, container runtime checks
  - `kots-support-bundle.yaml` -- Collectors and analyzers for Vaultwarden pods
  - `kurl-installer.yaml` -- kURL installer spec (Kubernetes 1.28, containerd, flannel, OpenEBS, MinIO, KOTS admin console)
  - `k8s-app.yaml` -- Kubernetes Application CRD with link to configured domain
- **Makefile** with working `release` target: `clean` -> `package-and-update` (dependency update, helm package, chartVersion sync) -> `replicated release create --yaml-dir`
- `validate` target cross-references KOTS Config items against HelmChart CR `ConfigOption`/`ConfigOptionEquals` references

## What was fixed

The `make release` target was the primary issue -- it was incomplete/missing. The complete chain is now:
1. `clean` removes old `.tgz` archives from manifests/
2. `update-chart-dependencies` pulls the Replicated SDK subchart
3. `package-and-update` packages the chart, copies the `.tgz` to manifests/, and syncs `chartVersion` in the HelmChart CR
4. `replicated release create --yaml-dir ./manifests --promote Unstable --auto -y` creates and promotes the release

## Known limitations

- Ingress TLS cert/key file Config items are defined but not mapped to HelmChart CR values (would require a TLS Secret template in the chart)
- No CI/CD workflow yet (would be a follow-up)

## Test plan

- [ ] Run `make lint` -- should pass with only the expected replicated dependency info
- [ ] Run `make release` with `REPLICATED_APP` set -- should create and promote a release to Unstable
- [ ] Verify the release appears in Vendor Portal with all manifests
- [ ] Install via kURL on a VM and confirm KOTS Config screen renders correctly

Generated with [Claude Code](https://claude.com/claude-code)